### PR TITLE
docs: Added OpenRouter setup page

### DIFF
--- a/get-started/bugs.mdx
+++ b/get-started/bugs.mdx
@@ -1,0 +1,11 @@
+---
+title: "Bug Reports"
+description: "Reported bugs and issues."
+---
+
+### 1. Bug Report - 2025-05-29
+
+test
+
+**Status:** Open  
+**Reported:** 2025-05-29

--- a/get-started/bugs.mdx
+++ b/get-started/bugs.mdx
@@ -2,10 +2,3 @@
 title: "Bug Reports"
 description: "Reported bugs and issues."
 ---
-
-### 1. Bug Report - 2025-05-29
-
-test
-
-**Status:** Open  
-**Reported:** 2025-05-29

--- a/get-started/faq.mdx
+++ b/get-started/faq.mdx
@@ -167,3 +167,7 @@ This can add up quickly, so it's important to keep tabs on your context bar.
 Also: Generally, as you use up more tokens, AI systems get more "confused". It's like if you passed a whole book to some and asked them to find a single word! This is why limiting context, keeping chats short, and passing only required files, helps actually *improve* your results.
 
 Now, back to the point of confusion: The amount of tokens you use has no effect on the # of Alex messages you've consumed from a billing perspective. We simplify things by counting each request to the AI model as 1 "message". Some messages could be cheaper, some more expensive, but we average it so that you spend less time counting tokens and prices.
+
+### 22. test
+
+test

--- a/get-started/faq.mdx
+++ b/get-started/faq.mdx
@@ -168,3 +168,7 @@ Also: Generally, as you use up more tokens, AI systems get more "confused". It's
 
 Now, back to the point of confusion: The amount of tokens you use has no effect on the # of Alex messages you've consumed from a billing perspective. We simplify things by counting each request to the AI model as 1 "message". Some messages could be cheaper, some more expensive, but we average it so that you spend less time counting tokens and prices.
 
+
+### 22. test
+
+test

--- a/get-started/faq.mdx
+++ b/get-started/faq.mdx
@@ -167,8 +167,3 @@ This can add up quickly, so it's important to keep tabs on your context bar.
 Also: Generally, as you use up more tokens, AI systems get more "confused". It's like if you passed a whole book to some and asked them to find a single word! This is why limiting context, keeping chats short, and passing only required files, helps actually *improve* your results.
 
 Now, back to the point of confusion: The amount of tokens you use has no effect on the # of Alex messages you've consumed from a billing perspective. We simplify things by counting each request to the AI model as 1 "message". Some messages could be cheaper, some more expensive, but we average it so that you spend less time counting tokens and prices.
-
-
-### 22. test
-
-test

--- a/keys/adding-openrouter-api-key.mdx
+++ b/keys/adding-openrouter-api-key.mdx
@@ -3,9 +3,9 @@ title: "Adding your API Key for OpenRouter"
 description: "Learn how to get your API Key"
 ---
 
-To use OpenRouter, a great way to add models and control spend, you'll need an OpenRouter API key.
+To use OpenRouter, a great way to add AI models and control spend, you'll need an OpenRouter API key.
 
-Here's how to grab your's:
+Here's how to get one:
 
 1. Visit [OpenRouter's API Key Settings](https://openrouter.ai/settings/keys)
 

--- a/keys/adding-openrouter-api-key.mdx
+++ b/keys/adding-openrouter-api-key.mdx
@@ -1,0 +1,36 @@
+---
+title: "Adding your API Key for OpenRouter"
+description: "Learn how to get your API Key"
+---
+
+To use OpenRouter, a great way to add models and control spend, you'll need an OpenRouter API key.
+
+Here's how to grab your's:
+
+1. Visit [OpenRouter's API Key Settings](https://openrouter.ai/settings/keys)
+
+2. Create an account or sign in if you already have one
+
+3. Click "Create API Key"
+
+4. Give your key a name (e.g., "Alex Sidebar") and optionally set a credit spend limit
+
+5. Copy the API key - make sure to save it somewhere secure as you won't be able to see it again
+
+6. 7. In Alex Sidebar:
+   - Open Settings (⚙️)
+   - Select "Models and API Keys" under the "Tools & Features" section
+   - Paste your OpenRouter API key in the OpenRouter key text field under the OpenRouter Models
+
+<Note>
+  Keep your API key secure and never share it publicly. If you suspect your key has been compromised, you should immediately rotate it in your OpenRouter settings.
+</Note>
+
+## Usage & Billing
+
+- OpenRouter is a unified API for all the major LLMs on the market, along with several minor ones. It allows users to aggregate their billing in one place and make use of several nice features such as analytics and fallbacks.
+- OpenRouter is **not**, an AI model. It is a platform in which you can connect to various models with various pricing and various limitations.
+
+<Note>
+You should familiarize yourself with their platform and [documentation](https://openrouter.ai/docs) before proceeding, if you haven't already.
+</Note>

--- a/keys/adding-openrouter-api-key.mdx
+++ b/keys/adding-openrouter-api-key.mdx
@@ -17,7 +17,7 @@ Here's how to get one:
 
 5. Copy the API key - make sure to save it somewhere secure as you won't be able to see it again
 
-6. 7. In Alex Sidebar:
+6. In Alex Sidebar:
    - Open Settings (⚙️)
    - Select "Models and API Keys" under the "Tools & Features" section
    - Paste your OpenRouter API key in the OpenRouter key text field under the OpenRouter Models

--- a/keys/adding-openrouter-api-key.mdx
+++ b/keys/adding-openrouter-api-key.mdx
@@ -29,7 +29,7 @@ Here's how to get one:
 ## Usage & Billing
 
 - OpenRouter is a unified API for all the major LLMs on the market, along with several minor ones. It allows users to aggregate their billing in one place and make use of several nice features such as analytics and fallbacks.
-- OpenRouter is **not**, an AI model. It is a platform in which you can connect to various models with various pricing and various limitations.
+- OpenRouter is **not** an AI model. It is a platform in which you can connect to various models with various pricing and various limitations.
 
 <Note>
 You should familiarize yourself with their platform and [documentation](https://openrouter.ai/docs) before proceeding, if you haven't already.

--- a/mint.json
+++ b/mint.json
@@ -71,7 +71,8 @@
         "keys/adding-fireworks-ai-api-key",
         "keys/adding-gemini-api-key",
         "keys/adding-openai-api-key",
-        "keys/adding-voyage-ai-api-key"
+        "keys/adding-voyage-ai-api-key",
+        "keys/adding-openrouter-api-key"
       ]
     },
     {


### PR DESCRIPTION
There are non-existent instructions linked to within Settings, so figured I would take the liberty of adding them. 

This merge should be accompanied with an updated hyperlink within AlexSideBar (Settings >> Tools & Features >> Models and API Keys >> OpenRouter Models >> OpenRouter Key).