### PR TITLE
Add dedicated pricing page

### DIFF
--- a/get-started/faq.mdx
+++ b/get-started/faq.mdx
@@ -168,28 +168,6 @@ Also: Generally, as you use up more tokens, AI systems get more "confused". It's
 
 Now, back to the point of confusion: The amount of tokens you use has no effect on the # of Alex messages you've consumed from a billing perspective. We simplify things by counting each request to the AI model as 1 "message". Some messages could be cheaper, some more expensive, but we average it so that you spend less time counting tokens and prices.
 
-### 22. Pricing Updates (June 27th, 2025)
+### 22. What are the pricing plans?
 
-1. We're adding a new **unlimited** plan! Lots of you asked for a fully unlimited plan after we held our 7-day-free promotion for WWDC. With this plan, you don't have to worry about chat credits & top-ups anymore. It's $200/mo for one device, with no rate limits.
-
-(The unlimited plan replaces Premium. Current Premium subscribers are grandfathered—you keep your plan until you choose to switch or cancel.)
-
-2. We're adding 100 chat credits to the Pro plan! It's upgraded from 500 -> 600 / mo, at the same price of $30/mo.
-
-- If you're on the $30/mo sub, you'll see an extra 100 messages added to your account.
-- If your $30/mo sub is set to cancel, you will not see the extra 100 messages added (this is because our billing migrator doesn't support migrating plans that are set to cancel. Please let us know if you change your cancellation status, and we will attempt to migrate your plan again.)
-- If you are on the old $20/mo sub, you will still have access to it until cancelled. It will remain at 500 credits / mo.
-
-3. Starting version 3.3 next monday (June 30th), **all users** will have access to GitHub Issues & Linear integrations! It's no longer gated to premium.
-
-4. We are renaming "Chat Messages" to "Chat Credits" to better reflect what it means. Nothing logically has changed, just naming.
-
-To re-iterate, a chat credit is deducted when:
-
-- You send a message
-- The agent does a follow-up action (e.g., if it does 3 action calls autonomously, that's 3 credits).
-- The agent requests images generated (1 credit per image, and 1 credit for the request). e.g. 3 credits for generating 2 images.
-
-5. Mini plan ($12/mo) remains the same. Old mini plan ($10/mo) is also grandfathered.
-
-6. These updates supercede anything in our docs, as the pricing in our docs might be out-of-date.
+Please see our dedicated [Pricing Plans](/get-started/pricing) page for current pricing information and plan details.

--- a/get-started/pricing.mdx
+++ b/get-started/pricing.mdx
@@ -1,0 +1,84 @@
+---
+title: "Pricing Plans"
+description: "Choose the plan that works best for your development workflow"
+---
+
+Alex Sidebar offers different plans based on how much you use the chat features. All paid plans include a 7-day free trial so you can test everything out before committing.
+
+All users (including free) get access to GitHub and Linear integrations.
+
+## Free Tier
+
+Great for trying out Alex Sidebar before committing to a subscription.
+
+- 15 messages per month for testing
+- Access to basic features
+- No credit card required
+
+## Mini Plan - $12/month
+
+Designed for developers who want to use their own API keys.
+
+- Unlimited Code Applies
+- Unlimited Tab-to-Complete  
+- Unlimited Codebase Embeddings
+- No chat credits included (bring your own API keys)
+- 7-day free trial
+
+## Pro Plan - $30/month
+
+Our most popular plan for active developers.
+
+- 600 Chat Credits per month
+- All Mini features included
+- Unlimited Voice Inputs
+- Unlimited Git Commit Generation  
+- Top-up available: $12.50 for 250 extra credits
+- 7-day free trial
+
+## Unlimited Plan - $200/month
+
+For power users who don't want to think about credits.
+
+- Unlimited Chat Credits
+- All Pro features included
+- No rate limits
+- 1 device limit
+- 7-day free trial
+
+## How Chat Credits Work
+
+Each interaction with Alex uses chat credits:
+
+- Sending a message: 1 credit
+- Agent follow-up actions: 1 credit per action (for example, if the agent performs 3 actions autonomously, that's 3 credits)
+- Image generation: 2 credits for the first image, 1 credit for each additional image
+
+### Credit Rollover Policy
+- Monthly credits do not roll over to the next month
+- Purchased top-up credits roll over to the next month
+
+## Grandfather Clauses
+
+We take care of our existing subscribers:
+
+- Premium subscribers (old plan) are grandfathered—you keep your plan until you choose to switch or cancel
+- Old Mini plan ($10/month) subscribers are also grandfathered
+
+<Note>
+These pricing updates supersede any other pricing information in our documentation.
+</Note>
+
+## Frequently Asked Questions
+
+### Can I change plans?
+Yes, you can upgrade or downgrade at any time. Changes take effect at the next billing cycle.
+
+### What payment methods do you accept?
+We accept all major credit cards through Stripe.
+
+### Do you offer team or enterprise pricing?
+Yes! Contact daniel@alexcodes.app for team and enterprise pricing options.
+
+### What happens when I run out of credits?
+You can purchase top-ups at $12.50 for 250 credits, or upgrade to the Unlimited plan.

--- a/mint.json
+++ b/mint.json
@@ -56,6 +56,7 @@
       "pages": [
         "get-started/introduction",
         "get-started/getting-started",
+        "get-started/pricing",
         "get-started/cheatsheet",
         "get-started/data-usage",
         "get-started/faq",


### PR DESCRIPTION
## Summary

This PR creates a dedicated pricing page and updates pricing information across the documentation.

## Changes

- Created new  page with complete pricing information
- Added free tier (15 messages/month)  
- Documented all plans: Mini (), Pro (), Unlimited ()
- Added GitHub and Linear integration note (available to all users)
- Updated FAQ to link to new pricing page instead of inline content
- Added pricing page to navigation menu

## Details

The new pricing page includes:
- Clear plan comparison
- Credit system explanation
- Rollover policies
- Grandfather clauses for existing subscribers
- FAQs about billing and plan changes